### PR TITLE
refactered osdjp.cpp

### DIFF
--- a/Includes/osdjp.hpp
+++ b/Includes/osdjp.hpp
@@ -9,6 +9,8 @@ namespace CTRPluginFramework
     Color bg;
     Clock time;
   };
-  bool OSDJP(const Screen &screen);
+
+  // bool OSDJP(const Screen &screen);
+
   bool OSDJPNotify(const std::string &str, const Color &foreground = Color::White, const Color &background = Color::Black);
 }

--- a/Sources/osdjp.cpp
+++ b/Sources/osdjp.cpp
@@ -1,6 +1,6 @@
 #include "osdjp.hpp"
 
-static constexpr auto notify_list_elements_max = 20;
+static constexpr auto notify_list_elements_max = 12;
 
 namespace CTRPluginFramework
 {
@@ -38,8 +38,9 @@ namespace CTRPluginFramework
 
     static const _reg_cb __cb;
 
-    if (OSDJPlist.size() >= notify_list_elements_max)
-      return false;
+    if (OSDJPlist.size() >= notify_list_elements_max) {
+      OSDJPlist.erase(OSDJPlist.begin());
+    }
 
     OSDJPlist.push_back({str, Color(fg.ToU32()), Color(bg.ToU32()), Clock()});
 

--- a/Sources/osdjp.cpp
+++ b/Sources/osdjp.cpp
@@ -1,38 +1,48 @@
 #include "osdjp.hpp"
 
+static constexpr auto notify_list_elements_max = 20;
+
 namespace CTRPluginFramework
 {
-  std::vector<Sys_OSD> OSDJPlist;
+  static std::vector<Sys_OSD> OSDJPlist;
 
-  bool OSDJP(const Screen &screen)
-  {
-    size_t i = 0;
+  static bool OSDJP_CallBack(const Screen &screen) {
+    // don't draw to bottom screen
     if (!screen.IsTop)
       return false;
-    while (i < OSDJPlist.size())
-    {
-      if (OSDJPlist[i].time.GetElapsedTime() <= Seconds(5))
-      {
-        int Leaght = OSD::GetTextWidth(true, OSDJPlist[i].name);
-        screen.DrawRect(380 - (Leaght + 2), 220 - (i * 20), Leaght + 4, 16 + 2, Color(OSDJPlist[i].bg.ToU32()));
-        screen.DrawSysfont(OSDJPlist[i].name, 380 - Leaght, 220 - (i * 20), Color(OSDJPlist[i].fg.ToU32()));
+
+    for( size_t i = 0; i < OSDJPlist.size(); ) {
+      if (OSDJPlist[i].time.GetElapsedTime() <= Seconds(5)) {
+        int width = OSD::GetTextWidth(true, OSDJPlist[i].name);
+
+        screen.DrawRect(380 - (width + 2), 220 - (i * 20), width + 4, 16 + 2, Color(OSDJPlist[i].bg.ToU32()));
+        screen.DrawSysfont(OSDJPlist[i].name, 380 - width, 220 - (i * 20), Color(OSDJPlist[i].fg.ToU32()));
+
         if (++i == 12)
           break;
       }
-      else
-      {
+      else {
         OSDJPlist.erase(OSDJPlist.begin() + i);
       }
     }
+
     return true;
   }
 
-  bool OSDJPNotify(const std::string &str, const Color &fg, const Color &bg)
-  {
-    OSD::Run(OSDJP);
-    if (OSDJPlist.size() >= 20)
+  bool OSDJPNotify(const std::string &str, const Color &fg, const Color &bg) {
+    struct _reg_cb {
+      _reg_cb() {
+        OSD::Run(OSDJP_CallBack);
+      }
+    };
+
+    static const _reg_cb __cb;
+
+    if (OSDJPlist.size() >= notify_list_elements_max)
       return false;
+
     OSDJPlist.push_back({str, Color(fg.ToU32()), Color(bg.ToU32()), Clock()});
+
     return true;
   }
 }


### PR DESCRIPTION
- OSDJPNotify を呼び出すたびに コールバック登録していたので、最初の呼び出し時のみ登録するようにした
- 通知リストとコールバック関数は公開する必要ないので static 付けた
- OSDJPlist の最大要素数を 20 から 12 に変更した（画面内にちょうど収まる数）
- 通知追加で最大要素数に達したとき、最初の通知を削除するようにした