### PR TITLE
Kani dev

### DIFF
--- a/Includes/JPKeyboard.hpp
+++ b/Includes/JPKeyboard.hpp
@@ -12,10 +12,11 @@ namespace CTRPluginFramework
 
     static bool LoadKanjiList(void);
 
-    void SetMaxLength(u32 max);
-    void CanSwich(bool canSwich);
-    void CanAbort(bool canAbort);
-    void CanConvert(bool canConvert);
+    JPKeyboard SetMaxLength(u32 max);
+    JPKeyboard CanSwichLayout(bool canSwich);
+    JPKeyboard CanAbort(bool canAbort);
+    JPKeyboard CanConvert(bool canConvert);
+    JPKeyboard SetDefaultLayout(bool isFlick);
     bool Open(std::string &out);
     bool Open(std::string &out, std::string defaultText);
 

--- a/Sources/Command.cpp
+++ b/Sources/Command.cpp
@@ -331,6 +331,10 @@ namespace CTRPluginFramework
   void Command::Cd(Directory &dir, std::string &path, std::string &str)
   {
     u64 pos = 18446744073709551615UL;
+
+    if (path.find("/") == 0)
+      path = path.substr(1);
+
     if (path.substr(0, 2) == "..")
     {
       Directory::Open(dir, dir.GetFullName().substr(0, FindAll(dir.GetFullName(), "/")[FindAll(dir.GetFullName(), "/").size() - 1]));


### PR DESCRIPTION
ローマ字入力したときにクラッシュするのを直した
メソッドチェーン追加
SetDefaultLayout追加
commandのcdにて引数の最初に/があると指定していないディレクトリに移動するバグの修正